### PR TITLE
Make asset sources environment variable aware.

### DIFF
--- a/devimages/controllers/DevImagesController.php
+++ b/devimages/controllers/DevImagesController.php
@@ -7,7 +7,9 @@ class DevImagesController extends BaseController
     {
         $this->requireAjaxRequest();
 
-        craft()->devImages->generateMissingImages();
+        $sources = craft()->request->getPost('sources');
+
+        craft()->devImages->generateMissingImages($sources);
 
         $clearCache = (bool) craft()->request->getPost('clearCache');
         if ($clearCache) {

--- a/devimages/services/DevImagesService.php
+++ b/devimages/services/DevImagesService.php
@@ -7,23 +7,37 @@ class DevImagesService extends BaseApplicationComponent
     /**
      * Generates randomly colored images present in the database but
      * not in the filesystem.
+     *
+     * @param $sourceIds array
      */
-    public function generateMissingImages()
+    public function generateMissingImages($sourceIds = null)
     {
+        if ($sourceIds === null)
+        {
+            return;
+        }
+
         // Get all the source paths first so we don't have to get them
         // while iterating through image assets.
         $paths = [];
         $sources = craft()->assetSources->getAllSources();
-        foreach($sources as $source) {
-            $paths[$source['id']] = $source['settings']['path'];
+        foreach ($sources as $source) {
+            if (in_array($source['id'], $sourceIds)) {
+                $paths[$source['id']] = craft()->config->parseEnvironmentString($source['settings']['path']);
+            }
         }
-
-        // Get all image asset elements
-        $images = craft()->elements->getCriteria(ElementType::Asset, ['kind' => 'image'])->findAll();
+        
+        // Get all image asset elements for the selected source IDs
+        $criteria = craft()->elements->getCriteria(ElementType::Asset);
+        $criteria->kind = 'image';
+        $criteria->limit = null;
+        $criteria->sourceId = $sourceIds;
+        $images = $criteria->find();
 
         // Generate images for missing files
-        foreach($images as $asset)
+        foreach ($images as $asset)
         {
+            /** @var AssetFileModel $asset */
             $path = $paths[$asset['sourceId']] . $asset->getPath();
             if ( ! IOHelper::fileExists($path)) {
                 craft()->devImages_image->createAndSave($asset->width, $asset->height, $path);

--- a/devimages/templates/_widget.twig
+++ b/devimages/templates/_widget.twig
@@ -3,7 +3,17 @@
 <form id="devimages" action="{{ actionUrl('devImages') }}" method="post" accept-charset="UTF-8">
     {{ getCsrfInput() }}
 
-    <p>Generates lightweight placeholder images for missing image assets.</p>
+    <p>Generates lightweight placeholder images for missing image assets. If any asset source  below is disabled, check that the asset sources 'file system path' exists and is writable.</p>
+
+    {% for source in sourceList %}
+		{{ forms.checkboxField({
+			label: source.source.name,
+			value: source.source.id,
+			checked: source.valid,
+			disabled: not source.valid,
+			name: 'sources[]'
+		}) }}
+    {% endfor %}
 
     {{ forms.checkbox({
         label: 'Clear all asset caches' | t,

--- a/devimages/widgets/DevImages_GenerateWidget.php
+++ b/devimages/widgets/DevImages_GenerateWidget.php
@@ -4,6 +4,12 @@ namespace Craft;
 
 class DevImages_GenerateWidget extends BaseWidget
 {
+
+	/**
+	 * @var bool
+	 */
+	public $multipleInstances = false;
+
     public function getName()
     {
         return Craft::t('Generate Missing Images');
@@ -15,7 +21,36 @@ class DevImages_GenerateWidget extends BaseWidget
             return false;
         }
 
+		$sourceList = $this->_getSourceList();
+
         craft()->templates->includeJsResource('devimages/js/devimages.js');
-        return craft()->templates->render('devimages/_widget');
+        return craft()->templates->render('devimages/_widget', array(
+	        'sourceList' => $sourceList
+        ));
     }
+
+	private function _getSourceList()
+	{
+		$sources = craft()->assetSources->getAllSources();
+
+		$sourceList = [];
+		foreach ($sources as $source)
+		{
+			$sourceList[$source->id] = [];
+			$sourceList[$source->id]['source'] = $source;
+			$sourceList[$source->id]['valid'] = true;
+
+			$path = craft()->config->parseEnvironmentString($source['settings']['path']);
+
+			if (strpos($path,'{') !== false) {
+				$sourceList[$source->id]['valid'] = false;
+			}
+
+			if ($sourceList[$source->id]['valid'] && !IOHelper::folderExists($path)) {
+				$sourceList[$source->id]['valid'] = false;
+			}
+		}
+
+		return $sourceList;
+	}
 }


### PR DESCRIPTION
Love this plugin!

I was having trouble generating images since the asset source locations did not exist due to environment variables in the source path.

In addition to allowing for environment variables, this pull request allows images to be generated optionally on a per source basis.

Asset sources that can not be written to, or include environment variables that cannot be parsed, will be disabled for generation  in the widget (until paths are fixed).